### PR TITLE
Normalize variable for switch statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,8 @@ AFRAME.registerSystem('preloader', {
 
             var eventName;
 
-            switch(assetItems[a].nodeName){
-                case 'A-ASSET-ITEM':
+            switch(assetItems[a].nodeName.toLowerCase()){
+                case 'a-asset-item':
                     eventName = 'loaded';
                     break;
                 case 'img':


### PR DESCRIPTION
When getting nodeName on my computer, it is in Upper Case.

ensure that nodeName is always compared using lower case.
This will ensure compatibility between browsers.